### PR TITLE
SearchGroup틀 제작

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { CssBaseline } from "@material-ui/core";
 import Login from "./pages/Login";
 import HomePage from "./pages/HomePage";
 import HisnetLogin from "./components/HisnetLogin";
+import SearchGroup from "./components/SearchGroup";
 
 const AuthOkay = ({ children }) => {
   const [auth, loading, error] = useAuthState(firebase.auth());
@@ -31,6 +32,7 @@ const App = () => {
               <Route path="/:engName/edit" exact component={EditPurchase} /> */}
             <Route path="/" exact component={HomePage} />
             <Route path="/hisnetlogin" exact component={HisnetLogin} />
+            <Route path="/group/:id" component={SearchGroup} />
           </Switch>
         </Router>
       </AuthOkay>

--- a/src/components/SearchGroup.css
+++ b/src/components/SearchGroup.css
@@ -1,6 +1,7 @@
-img {
+img[src="https://www.handong.edu/dcp/editor/images/01_CRA.png"]
+{
   border-radius: 50%;
 }
-* {
+.center {
   text-align: center;
 }

--- a/src/components/SearchGroup.css
+++ b/src/components/SearchGroup.css
@@ -1,5 +1,4 @@
-img[src="https://www.handong.edu/dcp/editor/images/01_CRA.png"]
-{
+.round {
   border-radius: 50%;
 }
 .center {

--- a/src/components/SearchGroup.css
+++ b/src/components/SearchGroup.css
@@ -1,0 +1,6 @@
+img {
+  border-radius: 50%;
+}
+* {
+  text-align: center;
+}

--- a/src/components/SearchGroup.jsx
+++ b/src/components/SearchGroup.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import { Grid } from "@material-ui/core";
+import { Alert, AlertTitle } from "@material-ui/lab";
 import "./SearchGroup.css";
 
 const SearchGroup = props => {
@@ -26,16 +27,32 @@ const SearchGroup = props => {
   return (
     <Grid container item justify="center">
       <div>
-        <div className={classes.root}>
-          <img src={groups[id].photo} width="150" height="150" alt="Avatar" />
-          <h1>{groups[id].name}</h1>
-          <h3>{groups[id].desc}</h3>
-          <h5>{groups[id].members}명 회원</h5>
-          <Button variant="contained">취소</Button>
-          <Button variant="contained" color="primary">
-            요청
-          </Button>
-        </div>
+        {groups[id] ? (
+          <div className={classes.root}>
+            <div className="center">
+              <img
+                src={groups[id].photo}
+                width="150"
+                height="150"
+                alt="Avatar"
+              />
+              <h1>{groups[id].name}</h1>
+              <h3>{groups[id].desc}</h3>
+              <h5>{groups[id].members}명 회원</h5>
+              <Button variant="contained">취소</Button>
+              <Button variant="contained" color="primary">
+                요청
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Alert severity="error">
+            <AlertTitle>Error</AlertTitle>
+            <strong>
+              데이터를 찾을 수가 없습니다. — 주소를 다시 확인해주세요.
+            </strong>
+          </Alert>
+        )}
       </div>
     </Grid>
   );
@@ -45,7 +62,9 @@ export default SearchGroup;
 
 const useStyles = makeStyles(theme => ({
   root: {
-    "& > *": {
+    width: "100%",
+    "& > * + *": {
+      marginTop: theme.spacing(2),
       margin: theme.spacing(1),
     },
   },

--- a/src/components/SearchGroup.jsx
+++ b/src/components/SearchGroup.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import { Grid } from "@material-ui/core";
+import "./SearchGroup.css";
+
+const SearchGroup = props => {
+  const groups = {
+    cra: {
+      name: "크라동아리",
+      type: "club", // club - 동아리, association - 학회, other - 기타
+      desc: "Computer Research Association",
+      photo: "https://www.handong.edu/dcp/editor/images/01_CRA.png",
+      members: 13, // 13 명
+    },
+    ghost: {
+      name: "고스트",
+      type: "club", // club - 동아리, association - 학회, other - 기타
+      desc: "고스트 동아리에 오신것을 환영합니다.",
+      photo: "https://www.handong.edu/dcp/editor/images/02_GHOST.png",
+      members: 10, // 10 명
+    },
+  };
+  const classes = useStyles();
+  const id = props.match.params.id;
+  return (
+    <Grid container item justify="center">
+      <div>
+        <div className={classes.root}>
+          <img src={groups[id].photo} width="150" height="150" alt="Avatar" />
+          <h1>{groups[id].name}</h1>
+          <h3>{groups[id].desc}</h3>
+          <h5>{groups[id].members}명 회원</h5>
+          <Button variant="contained">취소</Button>
+          <Button variant="contained" color="primary">
+            요청
+          </Button>
+        </div>
+      </div>
+    </Grid>
+  );
+};
+
+export default SearchGroup;
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    "& > *": {
+      margin: theme.spacing(1),
+    },
+  },
+}));

--- a/src/components/SearchGroup.jsx
+++ b/src/components/SearchGroup.jsx
@@ -35,7 +35,7 @@ const SearchGroup = props => {
                 width="150"
                 height="150"
                 alt="Avatar"
-                class="round"
+                className="round"
               />
               <h1>{groups[id].name}</h1>
               <h3>{groups[id].desc}</h3>

--- a/src/components/SearchGroup.jsx
+++ b/src/components/SearchGroup.jsx
@@ -35,6 +35,7 @@ const SearchGroup = props => {
                 width="150"
                 height="150"
                 alt="Avatar"
+                class="round"
               />
               <h1>{groups[id].name}</h1>
               <h3>{groups[id].desc}</h3>


### PR DESCRIPTION
json안의 요소를 .과 []로 가져오는 것의 차이를 배웠고, 동아리 이름들을 id로 정하여 props.match.params.id로 설정하였습니다. 
material ui를 이용하여 버튼을 넣었고, img를 넣을 때 alt를 Avatar로 정해 round 형태로 만들기 위해서 css에 border-radius: 50%를 설정하였습니다.

전체 items를 화면 정중앙에 배치하는 방법은 몰라요. vertically center 하는 건 나중에 찾아보겠습니당

<img width="276" alt="미션3 searchGroup" src="https://user-images.githubusercontent.com/74362214/105580376-5922d300-5dcf-11eb-9248-05f07768c705.PNG">
